### PR TITLE
Fix libcapsimage loading

### DIFF
--- a/absolute-path-for-libcapsimage.patch
+++ b/absolute-path-for-libcapsimage.patch
@@ -1,0 +1,12 @@
+diff -urN a/HxCFloppyEmulator/libhxcfe/trunk/sources/floppy_loader.c b/HxCFloppyEmulator/libhxcfe/trunk/sources/floppy_loader.c
+--- a/HxCFloppyEmulator/libhxcfe/trunk/sources/floppy_loader.c	2022-06-07 20:02:57.055255975 +1000
++++ b/HxCFloppyEmulator/libhxcfe/trunk/sources/floppy_loader.c	2022-06-07 20:06:10.120092735 +1000
+@@ -128,7 +128,7 @@
+ #elif __APPLE__
+ 		hxcfe_execScriptLine( hxcfe, "set SPSCAPS_LIB_NAME CAPSimage.framework/CAPSimage" );
+ #else
+-		hxcfe_execScriptLine( hxcfe, "set SPSCAPS_LIB_NAME libcapsimage.so.5.1" );
++		hxcfe_execScriptLine( hxcfe, "set SPSCAPS_LIB_NAME /app/extensions/capslib/extra/lib/libcapsimage.so.5.1" );
+ #endif
+ 
+ 		hxcfe_execScriptFile(hxcfe, "config.script");

--- a/fr.free.hxc2001.HxCFloppyEmulator.yaml
+++ b/fr.free.hxc2001.HxCFloppyEmulator.yaml
@@ -50,3 +50,5 @@ modules:
       - type: file
         url: https://www.fltk.org/pub/fltk/1.3.5/fltk-1.3.5-source.tar.gz
         sha256: 8729b2a055f38c1636ba20f749de0853384c1d3e9d1a6b8d4d1305143e115702
+      - type: patch
+        path: absolute-path-for-libcapsimage.patch


### PR DESCRIPTION
Without the included patch, loading libcapsimage.so.5.1 fails because the libhxcfe library, which is responsible for loading libcapsimage, attempts to dlopen libcapsimage.so.5.1, however the soname of the libcapsimage library is  libcapsimage.so.4, and the soname is what is found in /etc/ld.so.cache inside the flatpak sandbox.

I have tested this PR in a couple of ways.

1. Entering the flatpak sandbox with a shell and using the hxcfe command-line tool to attempt to list files in a .ipf disk image file.
2. Loading the HXC floppy emulator GUI application from my desktop shell, and dragging and dropping a .ipfdisk image  file onto the HXC floppy emulator window, with the GUI reporting the number of tracks in the image file. Failure to load an .ipf file without the fr.free.hxc2001.HxCFloppyEmulator.Extension.capslib extension shows a load error message.